### PR TITLE
Add methods and trait to allow entity deletion

### DIFF
--- a/event-sauce-derive/src/lib.rs
+++ b/event-sauce-derive/src/lib.rs
@@ -33,3 +33,13 @@ pub fn derive_update_event_data(input: TokenStream) -> TokenStream {
         Err(e) => e.to_compile_error().into(),
     }
 }
+
+#[proc_macro_derive(DeleteEventData, attributes(event_sauce))]
+pub fn derive_delete_event_data(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    match derives::event_data::expand_derive_delete_event_data(&input) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}

--- a/storage-sqlx/tests/pg_crud.rs
+++ b/storage-sqlx/tests/pg_crud.rs
@@ -1,6 +1,6 @@
 use event_sauce::{
-    AggregateCreate, AggregateUpdate, CreateEntityBuilder, Entity, Event, EventData, Persistable,
-    UpdateEntityBuilder,
+    AggregateCreate, AggregateUpdate, CreateEntityBuilder, Deletable, Entity, Event, EventData,
+    Persistable, UpdateEntityBuilder,
 };
 // use event_sauce::UpdateEntity;
 use event_sauce_storage_sqlx::SqlxPgStore;
@@ -70,6 +70,18 @@ impl Persistable<SqlxPgStore, User> for User {
             .await?;
 
         Ok(new)
+    }
+}
+
+#[async_trait::async_trait]
+impl Deletable<SqlxPgStore> for User {
+    async fn delete(self, store: &SqlxPgStore) -> Result<(), sqlx::Error> {
+        sqlx::query(&format!("delete from {} where id = $1", USERS_TABLE))
+            .bind(self.id)
+            .execute(&store.pool)
+            .await?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
E.g.:

```rust
#[async_trait::async_trait]
impl Deletable<SqlxPgStore> for User {
    async fn delete(self, store: &SqlxPgStore) -> Result<(), sqlx::Error> {
        sqlx::query(&format!("delete from {} where id = $1", USERS_TABLE))
            .bind(self.id)
            .execute(&store.pool)
            .await?;

        Ok(())
    }
}

// ...

user.try_delete(UserDeleted.into_event(None))
    .expect("Failed to create deletion event")
    .delete(&store)
    .await?;
```