### PR TITLE
Update deprecated lint directives

### DIFF
--- a/event-sauce/src/lib.rs
+++ b/event-sauce/src/lib.rs
@@ -7,7 +7,7 @@
 //! Core crate following the event sourcing paradigm.
 
 #![deny(missing_docs)]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 mod db_event;
 mod event;

--- a/storage-sqlx/src/lib.rs
+++ b/storage-sqlx/src/lib.rs
@@ -10,7 +10,7 @@
 //! - `with-postgres` (enabled by default) - Enable support for Postgres databases by exposing the `SqlxPgStore` storage adapter.
 
 #![deny(missing_docs)]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 use event_sauce::DeleteBuilderPersist;
 use event_sauce::StorageBackendTransaction;


### PR DESCRIPTION
Original code has been giving the following error:
renamed_and_removed_lints: lint `intra_doc_link_resolution_failure` has been renamed to `broken_intra_doc_links`  help: use the new name: `broken_intra_doc_links`