### PR TITLE
Fix bounds for generic event data payloads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ precheck_steps: &precheck_steps
     - run: rustup default ${RUST_VERSION:-stable}
     - run: cargo install cargo-readme
     - run: rustup component add rustfmt
-    - run: rustup toolchain add nightly
     - run: ./build.sh
     - save_cache:
         key: v2-event-sauce-{{ .Environment.CIRCLE_JOB }}-{{ checksum "event-sauce/Cargo.toml" }}-{{ checksum "event-sauce-derive/Cargo.toml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # Check that everything (tests, benches, etc) builds in std environments
 precheck_steps: &precheck_steps
   docker:
-    - image: circleci/rust:1.42.0
+    - image: circleci/rust:1.47.0
     - image: postgres:11-alpine
       environment:
         POSTGRES_USER: sauce
@@ -12,7 +12,6 @@ precheck_steps: &precheck_steps
     - restore_cache:
         key: v2-event-sauce-{{ .Environment.CIRCLE_JOB }}-{{ checksum "event-sauce/Cargo.toml" }}-{{ checksum "event-sauce-derive/Cargo.toml" }}
     - run: rustup self update
-    - run: cargo update
     - run: sudo apt install -qq linkchecker
     - run: rustup default ${RUST_VERSION:-stable}
     - run: cargo install cargo-readme
@@ -43,14 +42,3 @@ workflows:
   version: 2
   build_all:
     <<: *build_jobs
-
-  # Build every day
-  nightly:
-    <<: *build_jobs
-    triggers:
-      - schedule:
-          cron: '0 0 * * *'
-          filters:
-            branches:
-              only:
-                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ precheck_steps: &precheck_steps
     - restore_cache:
         key: v2-event-sauce-{{ .Environment.CIRCLE_JOB }}-{{ checksum "event-sauce/Cargo.toml" }}-{{ checksum "event-sauce-derive/Cargo.toml" }}
     - run: rustup self update
-    - run: sudo apt install -qq linkchecker
     - run: rustup default ${RUST_VERSION:-stable}
     - run: cargo install cargo-readme
     - run: rustup component add rustfmt

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ cargo test --release -- --test-threads=1
 cargo test --release --all-features -- --test-threads=1
 cargo bench --no-run
 
-cargo +nightly doc --all-features
+cargo doc --all-features
 
 # Crate-specific checks
 for crate in ${crates[@]}; do

--- a/build.sh
+++ b/build.sh
@@ -16,8 +16,6 @@ cargo doc --all-features
 
 # Crate-specific checks
 for crate in ${crates[@]}; do
-    linkchecker target/doc/event_sauce/index.html
-
     readme="target/check-${crate}-README.md"
 
     pushd $crate

--- a/event-sauce/Cargo.toml
+++ b/event-sauce/Cargo.toml
@@ -24,8 +24,6 @@ serde_json = "1.0.46"
 serde = "1.0.104"
 log = "0.4.8"
 serde_derive = "1.0.104"
-r2d2 = "0.8.8"
-r2d2_postgres = "0.16.0"
 async-trait = "0.1.29"
 sqlx = {optional = true, version = "0.3.5", features=["postgres", "uuid", "chrono", "macros", "json"]}
 

--- a/event-sauce/src/db_event.rs
+++ b/event-sauce/src/db_event.rs
@@ -60,7 +60,7 @@ pub struct DBEvent {
     pub purged_at: Option<DateTime<Utc>>,
 }
 
-impl<S: EventData> TryFrom<Event<S>> for DBEvent {
+impl<S: EventData + serde::Serialize> TryFrom<Event<S>> for DBEvent {
     type Error = serde_json::Error;
 
     /// Attempt to convert an [`Event`] into a `DBEvent`

--- a/event-sauce/src/event.rs
+++ b/event-sauce/src/event.rs
@@ -2,11 +2,12 @@
 
 use crate::{db_event::DBEvent, EventData};
 use chrono::{DateTime, Utc};
+use serde::Deserialize;
 use std::convert::TryFrom;
 use uuid::Uuid;
 
 /// Event definition
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
 pub struct Event<D>
 where
     D: EventData,
@@ -50,7 +51,7 @@ where
     pub purged_at: Option<DateTime<Utc>>,
 }
 
-impl<S: EventData> TryFrom<DBEvent> for Event<S> {
+impl<S: EventData + for<'de> Deserialize<'de>> TryFrom<DBEvent> for Event<S> {
     type Error = serde_json::Error;
 
     /// Attempt to decode a [`DBEvent`] into an `Event`

--- a/event-sauce/src/lib.rs
+++ b/event-sauce/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
     },
     triggers::{OnCreated, OnUpdated},
 };
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use uuid::Uuid;
 
 /// An entity to apply events to
@@ -41,7 +41,7 @@ pub trait Entity {
 }
 
 /// An event's data payload
-pub trait EventData: Serialize + for<'de> Deserialize<'de> {
+pub trait EventData: Serialize + Sized {
     /// The type of this event as a `PascalCase` string
     const EVENT_TYPE: &'static str;
 


### PR DESCRIPTION
Tested with this code:

```rust
#[derive(Serialize)]
struct ConflictEvent<A, B> {
    a: A,
    b: B,
}

impl<A, B> EventData for ConflictEvent<A, B>
where
    A: Serialize,
    B: Serialize,
{
    const EVENT_TYPE: &'static str = "Testo";

    type Entity = TestEnt;
    type Builder = CreateEventBuilder<Self>;
}

struct TestEnt;

impl Entity for TestEnt {
    const ENTITY_TYPE: &'static str = "Ento";

    fn entity_id(&self) -> Uuid {
        Uuid::new_v4()
    }
}
```

Also tested in cloudapi with a successful compile.