### PR TITLE
Turn event type to a function instead of constant

### DIFF
--- a/event-sauce-derive/src/derives/event_data.rs
+++ b/event-sauce-derive/src/derives/event_data.rs
@@ -102,8 +102,8 @@ fn expand_derive_event_data_struct(
 
             type Builder = #event_builder <#ident>;
 
-            fn event_type(&self) -> String {
-                String::from(#ident_string)
+            fn event_type(&self) -> &'static str {
+                #ident_string
             }
         }
 

--- a/event-sauce-derive/src/derives/event_data.rs
+++ b/event-sauce-derive/src/derives/event_data.rs
@@ -102,7 +102,9 @@ fn expand_derive_event_data_struct(
 
             type Builder = #event_builder <#ident>;
 
-            const EVENT_TYPE: &'static str = #ident_string;
+            fn event_type(&self) -> String {
+                String::from(#ident_string)
+            }
         }
 
         impl #builder_impl<#ident> for #entity {}

--- a/event-sauce/src/event_builder/create_event.rs
+++ b/event-sauce/src/event_builder/create_event.rs
@@ -83,7 +83,7 @@ where
     pub fn build(self) -> Event<D> {
         Event {
             id: Uuid::new_v4(),
-            event_type: D::event_type(&self.payload),
+            event_type: String::from(self.payload.event_type()),
             entity_type: D::Entity::entity_type(),
             entity_id: self.entity_id,
             session_id: self.session_id,

--- a/event-sauce/src/event_builder/create_event.rs
+++ b/event-sauce/src/event_builder/create_event.rs
@@ -82,15 +82,15 @@ where
     /// Consume the builder and produce the final event
     pub fn build(self) -> Event<D> {
         Event {
-            data: Some(self.payload),
             id: Uuid::new_v4(),
-            event_type: D::event_type(),
+            event_type: D::event_type(&self.payload),
             entity_type: D::Entity::entity_type(),
             entity_id: self.entity_id,
             session_id: self.session_id,
             purger_id: None,
             created_at: Utc::now(),
             purged_at: None,
+            data: Some(self.payload),
         }
     }
 }

--- a/event-sauce/src/event_builder/delete_event.rs
+++ b/event-sauce/src/event_builder/delete_event.rs
@@ -64,7 +64,7 @@ where
     pub fn build(self, entity: &D::Entity) -> Event<D> {
         Event {
             id: Uuid::new_v4(),
-            event_type: D::event_type(&self.payload),
+            event_type: String::from(self.payload.event_type()),
             entity_type: D::Entity::entity_type(),
             entity_id: entity.entity_id(),
             session_id: self.session_id,
@@ -80,7 +80,7 @@ where
     pub(crate) fn build_with_entity_id(self, entity_id: Uuid) -> Event<D> {
         Event {
             id: Uuid::new_v4(),
-            event_type: D::event_type(&self.payload),
+            event_type: String::from(self.payload.event_type()),
             entity_type: D::Entity::entity_type(),
             entity_id,
             session_id: self.session_id,

--- a/event-sauce/src/event_builder/delete_event.rs
+++ b/event-sauce/src/event_builder/delete_event.rs
@@ -63,15 +63,15 @@ where
     /// Consume the builder and produce the final event
     pub fn build(self, entity: &D::Entity) -> Event<D> {
         Event {
-            data: Some(self.payload),
             id: Uuid::new_v4(),
-            event_type: D::event_type(),
+            event_type: D::event_type(&self.payload),
             entity_type: D::Entity::entity_type(),
             entity_id: entity.entity_id(),
             session_id: self.session_id,
             purger_id: None,
             created_at: Utc::now(),
             purged_at: None,
+            data: Some(self.payload),
         }
     }
 
@@ -79,15 +79,15 @@ where
     /// `DeleteEntityBuilder`
     pub(crate) fn build_with_entity_id(self, entity_id: Uuid) -> Event<D> {
         Event {
-            data: Some(self.payload),
             id: Uuid::new_v4(),
-            event_type: D::event_type(),
+            event_type: D::event_type(&self.payload),
             entity_type: D::Entity::entity_type(),
             entity_id,
             session_id: self.session_id,
             purger_id: None,
             created_at: Utc::now(),
             purged_at: None,
+            data: Some(self.payload),
         }
     }
 }

--- a/event-sauce/src/event_builder/purge_event.rs
+++ b/event-sauce/src/event_builder/purge_event.rs
@@ -63,15 +63,15 @@ impl<D: EventData> PurgeEventBuilder<D> {
     /// `DeleteEntityBuilder`
     pub(crate) fn build_with_entity_id(self, entity_id: Uuid) -> Event<D> {
         Event {
-            data: None,
             id: Uuid::new_v4(),
-            event_type: D::event_type(),
+            event_type: D::event_type(&self.payload),
             entity_type: D::Entity::entity_type(),
             entity_id,
             session_id: self.session_id,
             purger_id: self.session_id,
             created_at: Utc::now(),
             purged_at: Some(Utc::now()),
+            data: None,
         }
     }
 

--- a/event-sauce/src/event_builder/purge_event.rs
+++ b/event-sauce/src/event_builder/purge_event.rs
@@ -64,7 +64,7 @@ impl<D: EventData> PurgeEventBuilder<D> {
     pub(crate) fn build_with_entity_id(self, entity_id: Uuid) -> Event<D> {
         Event {
             id: Uuid::new_v4(),
-            event_type: D::event_type(&self.payload),
+            event_type: String::from(self.payload.event_type()),
             entity_type: D::Entity::entity_type(),
             entity_id,
             session_id: self.session_id,

--- a/event-sauce/src/event_builder/update_event.rs
+++ b/event-sauce/src/event_builder/update_event.rs
@@ -79,7 +79,7 @@ where
     pub fn build(self, entity: &D::Entity) -> Event<D> {
         Event {
             id: Uuid::new_v4(),
-            event_type: D::event_type(&self.payload),
+            event_type: String::from(self.payload.event_type()),
             entity_type: D::Entity::entity_type(),
             entity_id: entity.entity_id(),
             session_id: self.session_id,
@@ -95,7 +95,7 @@ where
     pub(crate) fn build_with_entity_id(self, entity_id: Uuid) -> Event<D> {
         Event {
             id: Uuid::new_v4(),
-            event_type: D::event_type(&self.payload),
+            event_type: String::from(self.payload.event_type()),
             entity_type: D::Entity::entity_type(),
             entity_id,
             session_id: self.session_id,

--- a/event-sauce/src/event_builder/update_event.rs
+++ b/event-sauce/src/event_builder/update_event.rs
@@ -78,15 +78,15 @@ where
     /// Consume the builder and produce the final event
     pub fn build(self, entity: &D::Entity) -> Event<D> {
         Event {
-            data: Some(self.payload),
             id: Uuid::new_v4(),
-            event_type: D::event_type(),
+            event_type: D::event_type(&self.payload),
             entity_type: D::Entity::entity_type(),
             entity_id: entity.entity_id(),
             session_id: self.session_id,
             purger_id: None,
             created_at: Utc::now(),
             purged_at: None,
+            data: Some(self.payload),
         }
     }
 
@@ -94,15 +94,15 @@ where
     /// `UpdateEntityBuilder`
     pub(crate) fn build_with_entity_id(self, entity_id: Uuid) -> Event<D> {
         Event {
-            data: Some(self.payload),
             id: Uuid::new_v4(),
-            event_type: D::event_type(),
+            event_type: D::event_type(&self.payload),
             entity_type: D::Entity::entity_type(),
             entity_id,
             session_id: self.session_id,
             purger_id: None,
             created_at: Utc::now(),
             purged_at: None,
+            data: Some(self.payload),
         }
     }
 }

--- a/event-sauce/src/lib.rs
+++ b/event-sauce/src/lib.rs
@@ -49,7 +49,7 @@ pub trait EventData: Serialize + Sized {
     type Builder: EventBuilder<Self>;
 
     /// Get the event type/identifier in PascalCase like `UserCreated` or `PasswordChanged`
-    fn event_type(&self) -> String;
+    fn event_type(&self) -> &'static str;
 
     /// Convert the event into a builder with a given session ID
     ///

--- a/event-sauce/src/lib.rs
+++ b/event-sauce/src/lib.rs
@@ -42,9 +42,6 @@ pub trait Entity {
 
 /// An event's data payload
 pub trait EventData: Serialize + Sized {
-    /// The type of this event as a `PascalCase` string
-    const EVENT_TYPE: &'static str;
-
     /// The entity to bind this event to
     type Entity: Entity;
 
@@ -52,9 +49,7 @@ pub trait EventData: Serialize + Sized {
     type Builder: EventBuilder<Self>;
 
     /// Get the event type/identifier in PascalCase like `UserCreated` or `PasswordChanged`
-    fn event_type() -> String {
-        Self::EVENT_TYPE.to_string()
-    }
+    fn event_type(&self) -> String;
 
     /// Convert the event into a builder with a given session ID
     ///

--- a/storage-sqlx/tests/pg_crud.rs
+++ b/storage-sqlx/tests/pg_crud.rs
@@ -36,7 +36,9 @@ impl EventData for UserCreated {
     type Entity = User;
     type Builder = CreateEventBuilder<Self>;
 
-    const EVENT_TYPE: &'static str = "UserCreated";
+    fn event_type(&self) -> String {
+        String::from("UserCreated")
+    }
 }
 
 #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
@@ -48,7 +50,9 @@ impl EventData for UserEmailChanged {
     type Entity = User;
     type Builder = UpdateEventBuilder<Self>;
 
-    const EVENT_TYPE: &'static str = "UserEmailChanged";
+    fn event_type(&self) -> String {
+        String::from("UserEmailChanged")
+    }
 }
 
 #[async_trait::async_trait]

--- a/storage-sqlx/tests/pg_crud.rs
+++ b/storage-sqlx/tests/pg_crud.rs
@@ -36,8 +36,8 @@ impl EventData for UserCreated {
     type Entity = User;
     type Builder = CreateEventBuilder<Self>;
 
-    fn event_type(&self) -> String {
-        String::from("UserCreated")
+    fn event_type(&self) -> &'static str {
+        "UserCreated"
     }
 }
 
@@ -50,8 +50,8 @@ impl EventData for UserEmailChanged {
     type Entity = User;
     type Builder = UpdateEventBuilder<Self>;
 
-    fn event_type(&self) -> String {
-        String::from("UserEmailChanged")
+    fn event_type(&self) -> &'static str {
+        "UserEmailChanged"
     }
 }
 


### PR DESCRIPTION
This was surprisingly easy: `cloudapi/backend` seems to be working with just this change.